### PR TITLE
v1.0.3 Исправил переоткрытие слоя, если layersLimit = 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modul-ui-router",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/RouteManager.js
+++ b/src/RouteManager.js
@@ -86,27 +86,25 @@ export default class extends React.Component {
                 this.currentPage = basePagePath ? {pathname: basePagePath} : {pathname: '/'}
             }
 
-            if (this.layers.length >= this.props.layersLimit) {
-                layers.splice(0, 1, this.createLayer(location));
-                this.layers = layers;
-            } else {
-                const locationLayer = this.getLayerByLocation(location);
-                if (locationLayer) { //слой с таким урл уже есть в массиве
-                    const lastLayer = this.getLastLayer();
-                    if (lastLayer != locationLayer) {
-                        layers = layers.filter(s => s != locationLayer);
-                        layers.unshift(this.createLayer(location));
-                        this.layers = layers;
-
-                    } else {
-                        locationLayer.location = location;
-                        this.layers = layers;
-                    }
-                }
-                else {
+            const locationLayer = this.getLayerByLocation(location);
+            if (locationLayer) { //слой с таким урл уже есть в массиве
+                const lastLayer = this.getLastLayer();
+                if (lastLayer != locationLayer) {
+                    layers = layers.filter(s => s != locationLayer);
                     layers.unshift(this.createLayer(location));
                     this.layers = layers;
+
+                } else {
+                    locationLayer.location = location;
+                    this.layers = layers;
                 }
+            } else {
+                if (this.layers.length >= this.props.layersLimit) {
+                    // удаляем самый "нижний" слой из массива
+                    layers.pop();
+                }
+                layers.unshift(this.createLayer(location));
+                this.layers = layers;
             }
         } else {
             const layers = this.layers;


### PR DESCRIPTION
### Описание
Небольшой баг-фикс, который затрагивает хранение слоев в массиве.

### Проблема
Существует кейс, при котором происходит неверное занесения слоя в массив для хранения.

### Пример
Допустим у нас есть максимальное кол-во слоев (пять) и путь с уникальными id до этих слоев:
```
Слой1: 57aaf3e3-XXXX-YYYY-af9c-aac00277a4b8        <--- надо переоткрыть
Слой2: ddee6be3-XXXX-YYYY-abba-aabd01c57b99
Слой3: 2ec3302b-XXXX-YYYY-b9b3-aab9032d9550
Слой4: 1f6e29ac-XXXX-YYYY-8b1d-aab901ae2203
Слой5: da0c2ba9-XXXX-YYYY-b9f4-aab9019c232c
```

Где **Слой1** -- это самый нижний слой, а **Слой5** -- текущий открытый.
Надо переоткрыть **Слой1**.

**Ожидаемы результат**, массив выглядит:
```
Слой2: ddee6be3-XXXX-YYYY-abba-aabd01c57b99
Слой3: 2ec3302b-XXXX-YYYY-b9b3-aab9032d9550
Слой4: 1f6e29ac-XXXX-YYYY-8b1d-aab901ae2203
Слой5: da0c2ba9-XXXX-YYYY-b9f4-aab9019c232c
Слой1: 57aaf3e3-XXXX-YYYY-af9c-aac00277a4b8       <--- становится самым верхним
```

**Фактический результат**: 
```
Слой1: 57aaf3e3-XXXX-YYYY-af9c-aac00277a4b8        <--- надо переоткрыть
Слой2: ddee6be3-XXXX-YYYY-abba-aabd01c57b99
Слой3: 2ec3302b-XXXX-YYYY-b9b3-aab9032d9550
Слой4: 1f6e29ac-XXXX-YYYY-8b1d-aab901ae2203
Слой1: 57aaf3e3-XXXX-YYYY-af9c-aac00277a4b8        <--- становится самым верхним, с дублем
```
**Слой1** не удаляется с нулевой позиции, вместо него удаляется последний.

### Решение
Так как **Слой1** уже есть в массиве хранения, то достаточно перенести его в конец массива со сдвигом всех остальных индексов на -1.
Для этого в первую очередь надо проверить есть ли такой слой в массиве, а уже потом на максимальное кол-во открытых слоев.

<details>
    <summary>ui-router: v1.0.2</summary>
1, [ ... ] - это массив до переоткрытия Слой1,

2, [ ... ] - после перекотрытия Слой1

<img width="757" alt="v1 0 2" src="https://user-images.githubusercontent.com/10406538/64580975-9c36fe80-d3b2-11e9-8b01-b7e9307935b1.png">
</details>



<details>
    <summary>ui-router#fix/array-layers-on-reopen-same</summary>
1, [ ... ] - это массив до переоткрытия Слой1,

2, [ ... ] - после перекотрытия Слой1

<img width="754" alt="v1 0 3" src="https://user-images.githubusercontent.com/10406538/64580991-a527d000-d3b2-11e9-8457-7148ee42cefc.png">
</details>